### PR TITLE
商品購入機能実装後の処理の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -50,8 +50,7 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    @item = Item.find(params[:id])
-    unless user_signed_in? && current_user.id == @item.user.id
+    unless user_signed_in? && (current_user.id == @item.user.id) && @item.order.blank? 
       redirect_to root_path
     end
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,14 +131,11 @@
             <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
-
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <%# 商品購入機能実装後に実装 %>
-              <%# <div class='sold-out'> %>
-                <%# <span>Sold Out!!</span> %>
-              <%# </div> %>
-              <%# //商品が売れていればsold outを表示しましょう %>
-
+              <% if item.order.present? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> 
+              <% end %>
             </div>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,12 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# 購入機能未実装のため、一時的にコメントアウトしています %>
-      <%# <div class='sold-out'> %>
-        <%# <span>Sold Out!!</span> %>
-      <%# </div> %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order.present? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,8 +22,7 @@
         <%= @item.delivery_charge.name %>
       </span>
     </div>
-    <%# 購入機能未実装のため、売却済み商品に対して編集・削除が表示されない機能は未実装 %>
-    <% if user_signed_in? && current_user.id == @item.user.id %>
+    <% if user_signed_in? && (current_user.id == @item.user.id) && @item.order.blank? %>
       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.id) , method: :delete, class:'item-destroy' %>


### PR DESCRIPTION
# WHAT
売却済み商品に対する処理を実装

# WHY
商品購入機能を実装したので、売却済み商品に対して、処理を設定する必要があるため

### Gyazoのリンク
- 商品一覧ページの様子（売却済み商品にsold out表示）
https://gyazo.com/1ff51d11f2351139ef7ad227d340645c

- 商品詳細ページの様子（売却済み商品にsold out表示, 編集・削除が表示されない）https://gyazo.com/b09e465a1534ee0307feef178de693e8

- 商品情報編集ページへのアクセス制限（売却済み商品かつログイン中の出品者が遷移した場合）
https://gyazo.com/ff8179a652940629f95bf5b154f07f2b

- 商品情報編集ページへのアクセス制限（売却済み商品かつログイン中の出品者以外が遷移した場合）
https://gyazo.com/e37a9e68df98bbf2fae7a49e497f7835